### PR TITLE
Enable Python 3.5 and up for builds/testing

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -11,6 +11,3 @@ libsabergen = {editable = true, path = "./libsabergen"}
 
 [dev-packages]
 pylint = "==2.1.1"
-
-[requires]
-python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,12 +1,10 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "d1ede234ee8d030dcd8b8ac6a7e9f3004a58c65c20312c7ee496a157a92c4f89"
+            "sha256": "49482f9eadc5c390c36db7eb469dcec59728d68560f33956074c0f4c6274df37"
         },
         "pipfile-spec": 6,
-        "requires": {
-            "python_version": "3.7"
-        },
+        "requires": {},
         "sources": [
             {
                 "name": "pypi",

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,10 +10,10 @@ jobs:
     vmImage: 'Ubuntu 16.04'
   strategy:
     matrix:
-      # Python35:
-      #   python.version: '3.5'
-      # Python36:
-      #   python.version: '3.6'
+      Python35:
+        python.version: '3.5'
+      Python36:
+        python.version: '3.6'
       Python37:
         python.version: '3.7'
     maxParallel: 3

--- a/libsabergen/setup.py
+++ b/libsabergen/setup.py
@@ -7,4 +7,13 @@ setuptools.setup(
     author_email="",
     description="libsabergen description",
     packages=setuptools.find_packages(),
+    classifiers=[
+        "Development Status :: 1 - Planning",
+        "Programming Language :: Python :: 3 :: Only",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+    ]
 )


### PR DESCRIPTION
Moves knowledge of required version from pipenv to setup.py