### PR TITLE
Restructure lib/cli relationship

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,35 @@
 # sabergen
+
 Beat Saber song generator
 
-# Installation / Development
-## Installing Python/Pipenv
-You probably already have python.  Just make sure you have 3.7.\*.  Only chumps use 2.\*
+## Installation / Development
+
+### Installing Python/Pipenv
+
+You probably already have python.  Just make sure you have 3.5 or higher.  Only chumps use 2.\*
 To get pipenv on OSX, you'll need xcode-select, then brew install pipenv.
-```
-$ xcode-select --install
-$ brew install pipenv
-```
-For other operating systems, see https://pipenv.readthedocs.io/en/latest/install/#installing-pipenv
-## Installing python and dependencies
-Once pipenv is installed,
-```
-$ cd /path/to/sabergen/
-$ pipenv install
+
+```bash
+xcode-select --install
+brew install pipenv
 ```
 
-You'll also need ffmpeg
+For other operating systems, see [pipenv's documentation](https://pipenv.readthedocs.io/en/latest/install/#installing-pipenv).
+
+### Installing python and dependencies
+
+Once pipenv is installed,
+
+```bash
+cd /path/to/sabergen/
+pipenv install --dev
 ```
-http://www.ffmpeg.org/download.html
+
+You'll also need [ffmpeg](https://www.ffmpeg.org/download.html). Note that you will need
+to have the libvorbis encoder.
+
+Installing on macOS using `brew`:
+
+```bash
+brew install ffmpeg --with-theora --with-libvorbis --with-libvpx
 ```

--- a/cli/sabergen_cli.py
+++ b/cli/sabergen_cli.py
@@ -10,24 +10,21 @@ def main():
     parser.add_argument('-p', '--pyplot', action='store_true', help='Display song as pyplot')
     # Todo: subparsers rather than --pyplot or --show-beats; makes args easier to sort
     parser.add_argument('-b', '--show-beats', action='store_true', help='Show beats upon which there is a beat')
-    parser.add_argument('--bpm', type=int, help='Beats per minute', default=120)
+    parser.add_argument('--bpm', type=int, help='Estimated beats per minute', default=120)
     parser.add_argument('-d', '--debug', action='store_true', help='Print debug info')
 
     args = parser.parse_args()
     
-    beat_saber_song = beatSaberSong(args.input_path, args.debug)
-
-    # We only handle ogg from here
-    if not beat_saber_song.is_ogg(beat_saber_song.song_path):
-        print('Input specified is not an ogg. Converting to mp3')
-        beat_saber_song.convert_to_ogg(beat_saber_song.song_path)
+    song = beatSaberSong(args.debug)
+    song.load(args.input_path)
 
     if args.pyplot:
         print('Plotting song...')
-        beat_saber_song.display_song_as_pyplot()
+        song.display_song_as_pyplot()
+        
     if args.show_beats:
         print('Genearting BPM...')
-        print(beat_saber_song.get_beats(args.bpm))
+        print(song.get_beats(args.bpm))
 
 if __name__ == '__main__':
     main()

--- a/libsabergen/sabergen.py
+++ b/libsabergen/sabergen.py
@@ -11,12 +11,23 @@ import librosa
 import librosa.display as disp
 
 class beatSaberSong(object):
-    def __init__(self, song_path, debug):
-        self.song_path = song_path
+    def __init__(self, debug=False):
         self.debug = debug
+        self.y = None
+        self.sr = None
+        self.audio_path = None
+
+    def load(self, audio_path):
+        "Loads the audio file at the specified path. Converts to ogg if necessary."
+        self.audio_path = audio_path
+
+        if not self.is_ogg(audio_path):
+            self.audio_path = self.convert_to_ogg(audio_path)
+
+        self.y, self.sr = librosa.load(self.audio_path)
 
     def is_ogg(self, song_path):
-        """ Using the magic number of a file, determine if this is an .ogg file. """
+        "Using the magic number of a file, determine if this is an .ogg file."
         
         # Assuming we aren't opening a huge file.
         with open(song_path, "rb") as song:
@@ -34,10 +45,7 @@ class beatSaberSong(object):
 
     def convert_to_ogg(self, song_path):
         """
-        Takes a song path in that is not a .ogg 
-        and converts it to one. This generates an .ogg file in the same path as the song_path.
-        After conversion is done, it sets the beatSaberSong.song_path to the new .ogg path as
-        the library will only interface further with that file format.
+        Converts file at the provided path to ogg.
 
         WARNING: Care shall be taken by the caller of this function as it will explictly
         overwrite files that match the non-.ogg filename.
@@ -50,42 +58,49 @@ class beatSaberSong(object):
         
         try:
             # Setup new file name and path.
-            filename, prev_format_extension = path.splitext(path.basename(song_path))
+            filename, _ = path.splitext(path.basename(song_path))
             ogg_filename = "{}.ogg".format(filename)    
             ogg_path = path.join(path.dirname(song_path), ogg_filename)
 
-            # Convert with subprocess call
             # Command will generate a new file with the same name, except .ogg
             # -c:a codec, -y overwrite if output exists, -q quality specifier
-            convert = subprocess.run(["ffmpeg","-y", "-i", song_path, "-c:a", "libvorbis", "-q:a", "4", ogg_path], stdout=subprocess.PIPE, stderr=subprocess.STDOUT )
+            subprocess.run("ffmpeg -y -i {} -c:a libvorbis -q:a 8 {}".format(song_path, ogg_path),
+                shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True)
 
-            #Set song path to the new .ogg file
-            self.song_path = ogg_path
-            
             if self.debug:
-                return convert.stdout
-            else:
-                return
-        except Exception as e:
-            # Failed to convert song. Probably dump out of the program at this point
+                # TODO: How best to return stdout/stderr from a library?
+                pass
+
+            return ogg_path
+
+        except subprocess.CalledProcessError as e:
+            # FIXME: Need to find a better way to return a result object to callers
+            # since we likely shouldn't blindly produce stdout/stderr. Perhaps take in a logger?
+            # What logging libraries are popular in Python?
+            print(e.args)
+            print(e.stderr)
+            print(e.stdout)
+            raise
+
+        except Exception:
             raise
     
     def display_song_as_pyplot(self):
-        y, sr = librosa.load(self.song_path)
-
+        "Plots spectrogram magnitude using matplotlib."
         # Compute spectrogram magnitude and phase
-        S_full, phase = librosa.magphase(librosa.stft(y))
+        S_full, _ = librosa.magphase(librosa.stft(self.y))
 
-        idx = slice(*librosa.time_to_frames([30, 35], sr=sr))
+        idx = slice(*librosa.time_to_frames([30, 35], sr=self.sr))
         plt.figure(figsize=(12, 4))
         disp.specshow(librosa.amplitude_to_db(S_full[:, idx], ref=np.max),
-                    y_axis='log', x_axis='time', sr=sr)
+                    y_axis='log', x_axis='time', sr=self.sr)
         plt.colorbar()
         plt.tight_layout()
 
         plt.show()
 
     def get_beats(self, bpm=120):
-        y, sr = librosa.load(self.song_path)
-        tempo, beats = librosa.beat.beat_track(y, sr, bpm=bpm)
-        return beats
+        "Identify beat timestamps in the audio."
+        _, beat_frames = librosa.beat.beat_track(self.y, self.sr, bpm=bpm)
+        beat_times = librosa.frames_to_time(beat_frames, sr=self.sr)
+        return beat_times


### PR DESCRIPTION
This change moves more of the concerns into the library (it seems better to have the library
enforce the ogg format requirement than have all callers mandate it). It still leaves the
same public API surface in case the caller does want to change the behavior but load now
handles the main concern (only ogg format past a certain point).

Also add more details to the wiki for getting ffmpeg successfully installed with the necessary
codecs etc. It is probably we will need to add more in the future (the ones included are the
ones I needed to successfully convert an mp3 I was testing with).