### PR TITLE
Enable pylint and refactoring tooling

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,479 @@
+[MASTER]
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code.
+extension-pkg-whitelist=
+
+# Add files or directories to the blacklist. They should be base names, not
+# paths.
+ignore=CVS
+
+# Add files or directories matching the regex patterns to the blacklist. The
+# regex matches against base names, not paths.
+ignore-patterns=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
+# number of processors available to use.
+jobs=1
+
+# Control the amount of potential inferred values when inferring a single
+# object. This can help the performance when dealing with large functions or
+# complex, nested conditions.
+limit-inference-results=100
+
+# List of plugins (as comma separated values of python modules names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# Specify a configuration file.
+#rcfile=
+
+# When enabled, pylint would attempt to guess common misconfiguration and emit
+# user-friendly hints instead of false-positive error messages.
+suggestion-mode=yes
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED.
+confidence=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once). You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use "--disable=all --enable=classes
+# --disable=W".
+disable=
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+enable=c-extension-no-member
+
+
+[REPORTS]
+
+# Python expression which should return a note less than 10 (10 is the highest
+# note). You have access to the variables errors warning, statement which
+# respectively contain the number of errors / warnings messages and the total
+# number of statements analyzed. This is used by the global evaluation report
+# (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details.
+#msg-template=
+
+# Set the output format. Available formats are text, parseable, colorized, json
+# and msvs (visual studio). You can also give a reporter class, e.g.
+# mypackage.mymodule.MyReporterClass.
+output-format=text
+
+# Tells whether to display a full report or only the messages.
+reports=no
+
+# Activate the evaluation score.
+score=yes
+
+
+[REFACTORING]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
+
+# Complete name of functions that never returns. When checking for
+# inconsistent-return-statements if a never returning function is called then
+# it will be considered as an explicit return statement and no message will be
+# printed.
+never-returning-functions=sys.exit
+
+
+[LOGGING]
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format.
+logging-modules=logging
+
+
+[SPELLING]
+
+# Limits count of emitted suggestions for spelling mistakes.
+max-spelling-suggestions=4
+
+# Spelling dictionary name. Available dictionaries: none. To make it working
+# install python-enchant package..
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to indicated private dictionary in
+# --spelling-private-dict-file option instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,
+      XXX,
+      TODO
+
+
+[TYPECHECK]
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# Tells whether to warn about missing members when the owner of the attribute
+# is inferred to be None.
+ignore-none=yes
+
+# This flag controls whether pylint should warn about no-member and similar
+# checks whenever an opaque object is returned when inferring. The inference
+# can return multiple potential results while evaluating a Python object, but
+# some branches might not be evaluated, which results in partial inference. In
+# that case, it might be useful to still emit no-member and other checks for
+# the rest of the inferred objects.
+ignore-on-opaque-inference=yes
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis. It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=
+
+# Show a hint with possible names when a member name was not found. The aspect
+# of finding the hint is based on edit distance.
+missing-member-hint=yes
+
+# The minimum edit distance a name should have in order to be considered a
+# similar match for a missing member name.
+missing-member-hint-distance=1
+
+# The total number of similar names that should be taken in consideration when
+# showing a hint for a missing member.
+missing-member-max-choices=1
+
+
+[VARIABLES]
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid to define new builtins when possible.
+additional-builtins=
+
+# Tells whether unused global variables should be treated as a violation.
+allow-global-unused-variables=yes
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,
+          _cb
+
+# A regular expression matching the name of dummy variables (i.e. expected to
+# not be used).
+dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore.
+ignored-argument-names=_.*|^ignored_|^unused_
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,past.builtins,future.builtins,builtins,io
+
+
+[FORMAT]
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Number of spaces of indent required inside a hanging  or continued line.
+indent-after-paren=4
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Maximum number of characters on a single line.
+max-line-length=100
+
+# Maximum number of lines in a module.
+max-module-lines=1000
+
+# List of optional constructs for which whitespace checking is disabled. `dict-
+# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
+# `trailing-comma` allows a space between comma and closing bracket: (a, ).
+# `empty-line` allows space-only lines.
+no-space-check=trailing-comma,
+               dict-separator
+
+# Allow the body of a class to be on the same line as the declaration if body
+# contains single statement.
+single-line-class-stmt=no
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+
+[SIMILARITIES]
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=no
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+
+[BASIC]
+
+# Naming style matching correct argument names.
+argument-naming-style=snake_case
+
+# Regular expression matching correct argument names. Overrides argument-
+# naming-style.
+#argument-rgx=
+
+# Naming style matching correct attribute names.
+attr-naming-style=snake_case
+
+# Regular expression matching correct attribute names. Overrides attr-naming-
+# style.
+#attr-rgx=
+
+# Bad variable names which should always be refused, separated by a comma.
+bad-names=foo,
+          bar,
+          baz,
+          toto,
+          tutu,
+          tata
+
+# Naming style matching correct class attribute names.
+class-attribute-naming-style=any
+
+# Regular expression matching correct class attribute names. Overrides class-
+# attribute-naming-style.
+#class-attribute-rgx=
+
+# Naming style matching correct class names.
+class-naming-style=PascalCase
+
+# Regular expression matching correct class names. Overrides class-naming-
+# style.
+#class-rgx=
+
+# Naming style matching correct constant names.
+const-naming-style=UPPER_CASE
+
+# Regular expression matching correct constant names. Overrides const-naming-
+# style.
+#const-rgx=
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+# Naming style matching correct function names.
+function-naming-style=snake_case
+
+# Regular expression matching correct function names. Overrides function-
+# naming-style.
+#function-rgx=
+
+# Good variable names which should always be accepted, separated by a comma.
+good-names=i,
+           j,
+           k,
+           ex,
+           Run,
+           _
+
+# Include a hint for the correct naming format with invalid-name.
+include-naming-hint=no
+
+# Naming style matching correct inline iteration names.
+inlinevar-naming-style=any
+
+# Regular expression matching correct inline iteration names. Overrides
+# inlinevar-naming-style.
+#inlinevar-rgx=
+
+# Naming style matching correct method names.
+method-naming-style=snake_case
+
+# Regular expression matching correct method names. Overrides method-naming-
+# style.
+#method-rgx=
+
+# Naming style matching correct module names.
+module-naming-style=snake_case
+
+# Regular expression matching correct module names. Overrides module-naming-
+# style.
+#module-rgx=
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+# These decorators are taken in consideration only for invalid-name.
+property-classes=abc.abstractproperty
+
+# Naming style matching correct variable names.
+variable-naming-style=snake_case
+
+# Regular expression matching correct variable names. Overrides variable-
+# naming-style.
+#variable-rgx=
+
+
+[IMPORTS]
+
+# Allow wildcard imports from modules that define __all__.
+allow-wildcard-with-all=no
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+# Deprecated modules which should not be used, separated by a comma.
+deprecated-modules=optparse,tkinter.tix
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled).
+ext-import-graph=
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled).
+import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled).
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant
+
+
+[CLASSES]
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,
+                      __new__,
+                      setUp
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,
+                  _fields,
+                  _replace,
+                  _source,
+                  _make
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=cls
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method.
+max-args=5
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Maximum number of boolean expressions in an if statement.
+max-bool-expr=5
+
+# Maximum number of branch for function / method body.
+max-branches=12
+
+# Maximum number of locals for function / method body.
+max-locals=15
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+# Maximum number of return / yield for function / method body.
+max-returns=6
+
+# Maximum number of statements in function / method body.
+max-statements=50
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "Exception".
+overgeneral-exceptions=Exception

--- a/Pipfile
+++ b/Pipfile
@@ -11,3 +11,5 @@ libsabergen = {editable = true, path = "./libsabergen"}
 
 [dev-packages]
 pylint = "==2.1.1"
+rope = "==0.11.0"
+"autopep8" = "==1.4"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "49482f9eadc5c390c36db7eb469dcec59728d68560f33956074c0f4c6274df37"
+            "sha256": "0c53b7a33f3382a2c05f279b9abbb1b7810f15078aa902235101784fe54b6fa2"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -339,6 +339,13 @@
             ],
             "version": "==2.0.4"
         },
+        "autopep8": {
+            "hashes": [
+                "sha256:655e3ee8b4545be6cfed18985f581ee9ecc74a232550ee46e9797b6fbf4f336d"
+            ],
+            "index": "pypi",
+            "version": "==1.4"
+        },
         "isort": {
             "hashes": [
                 "sha256:1153601da39a25b14ddc54955dbbacbb6b2d19135386699e2ad58517953b34af",
@@ -389,6 +396,13 @@
             ],
             "version": "==0.6.1"
         },
+        "pycodestyle": {
+            "hashes": [
+                "sha256:cbc619d09254895b0d12c2c691e237b2e91e9b2ecf5e84c26b35400f93dcfb83",
+                "sha256:cbfca99bd594a10f674d0cd97a3d802a1fdef635d4361e1a2658de47ed261e3a"
+            ],
+            "version": "==2.4.0"
+        },
         "pylint": {
             "hashes": [
                 "sha256:1d6d3622c94b4887115fe5204982eee66fdd8a951cf98635ee5caee6ec98c3ec",
@@ -396,6 +410,13 @@
             ],
             "index": "pypi",
             "version": "==2.1.1"
+        },
+        "rope": {
+            "hashes": [
+                "sha256:a108c445e1cd897fe19272ab7877d172e7faf3d4148c80e7d20faba42ea8f7b2"
+            ],
+            "index": "pypi",
+            "version": "==0.11.0"
         },
         "six": {
             "hashes": [

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,6 +36,12 @@ jobs:
   - script: |
       python_path=`python -m site --user-base`
       pipenv="${python_path}/bin/pipenv"
+      ${pipenv} run pylint --rcfile .pylintrc libsabergen cli webserver || true
+    displayName: 'Run pylint'
+
+  - script: |
+      python_path=`python -m site --user-base`
+      pipenv="${python_path}/bin/pipenv"
       ${pipenv} run python cli/sabergen_cli.py --help
     displayName: 'Test invocation of CLI'
 

--- a/cli/sabergen_cli.py
+++ b/cli/sabergen_cli.py
@@ -1,27 +1,36 @@
 #!/usr/bin/env python3
 
+"""
+sabergen command line tool
+"""
+
 import argparse
-from sabergen import beatSaberSong
+from sabergen import BeatSaberSong
 
 def main():
+    """
+    Main dispatch method. Parse arguments and invoke appropriate library behaviors.
+    """
+
     parser = argparse.ArgumentParser()
 
     parser.add_argument('-i', '--input-path', help='Path to input music file', required=True)
     parser.add_argument('-p', '--pyplot', action='store_true', help='Display song as pyplot')
     # Todo: subparsers rather than --pyplot or --show-beats; makes args easier to sort
-    parser.add_argument('-b', '--show-beats', action='store_true', help='Show beats upon which there is a beat')
+    parser.add_argument('-b', '--show-beats', action='store_true',
+                        help='Show beats upon which there is a beat')
     parser.add_argument('--bpm', type=int, help='Estimated beats per minute', default=120)
     parser.add_argument('-d', '--debug', action='store_true', help='Print debug info')
 
     args = parser.parse_args()
-    
-    song = beatSaberSong(args.debug)
+
+    song = BeatSaberSong(args.debug)
     song.load(args.input_path)
 
     if args.pyplot:
         print('Plotting song...')
         song.display_song_as_pyplot()
-        
+
     if args.show_beats:
         print('Genearting BPM...')
         print(song.get_beats(args.bpm))

--- a/libsabergen/sabergen.py
+++ b/libsabergen/sabergen.py
@@ -1,20 +1,31 @@
 #!/usr/bin/env python3
 
-import numpy as np
+"""
+sabergen library to drive song generation for Beat Saber
+"""
 
-# Configure matplotlib for use with virtualenv
-import matplotlib
-matplotlib.use('TkAgg')
-from matplotlib import pyplot as plt
+import numpy as np
 
 import librosa
 import librosa.display as disp
 
-class beatSaberSong(object):
+# Configure matplotlib for use with virtualenv
+import matplotlib
+matplotlib.use('TkAgg')
+# Ignore the pylint error as we need to specify, explicitly, a backend
+# pylint: disable=wrong-import-position
+from matplotlib import pyplot as plt
+
+class BeatSaberSong:
+    """
+    Represents container of knowledge and logic for converting a provided
+    audio file into a Beat Saber song.
+    """
+
     def __init__(self, debug=False):
         self.debug = debug
-        self.y = None
-        self.sr = None
+        self.time_series = None
+        self.sampling_rate = None
         self.audio_path = None
 
     def load(self, audio_path):
@@ -24,23 +35,23 @@ class beatSaberSong(object):
         if not self.is_ogg(audio_path):
             self.audio_path = self.convert_to_ogg(audio_path)
 
-        self.y, self.sr = librosa.load(self.audio_path)
+        self.time_series, self.sampling_rate = librosa.load(self.audio_path)
 
     def is_ogg(self, song_path):
         "Using the magic number of a file, determine if this is an .ogg file."
-        
+
         # Assuming we aren't opening a huge file.
         with open(song_path, "rb") as song:
             # Load the first 4 bytes
             song_bytes = song.read(4)
-            
+
             # Turn those hex bytes into a string.
             hex_bytes = ''.join(['{:02X}'.format(byte) for byte in song_bytes])
-            
+
             # Magic number of ogg is OggS in ASCII
             if hex_bytes == '4F676753':
                 return True
-        
+
         return False
 
     def convert_to_ogg(self, song_path):
@@ -55,17 +66,17 @@ class beatSaberSong(object):
         # This is already a slower call.
         import subprocess
         from os import path
-        
+
         try:
             # Setup new file name and path.
             filename, _ = path.splitext(path.basename(song_path))
-            ogg_filename = "{}.ogg".format(filename)    
+            ogg_filename = "{}.ogg".format(filename)
             ogg_path = path.join(path.dirname(song_path), ogg_filename)
 
             # Command will generate a new file with the same name, except .ogg
             # -c:a codec, -y overwrite if output exists, -q quality specifier
             subprocess.run("ffmpeg -y -i {} -c:a libvorbis -q:a 8 {}".format(song_path, ogg_path),
-                shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True)
+                           shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True)
 
             if self.debug:
                 # TODO: How best to return stdout/stderr from a library?
@@ -73,27 +84,24 @@ class beatSaberSong(object):
 
             return ogg_path
 
-        except subprocess.CalledProcessError as e:
+        except subprocess.CalledProcessError as err:
             # FIXME: Need to find a better way to return a result object to callers
             # since we likely shouldn't blindly produce stdout/stderr. Perhaps take in a logger?
             # What logging libraries are popular in Python?
-            print(e.args)
-            print(e.stderr)
-            print(e.stdout)
+            print(err.args)
+            print(err.stderr)
+            print(err.stdout)
             raise
 
-        except Exception:
-            raise
-    
     def display_song_as_pyplot(self):
         "Plots spectrogram magnitude using matplotlib."
         # Compute spectrogram magnitude and phase
-        S_full, _ = librosa.magphase(librosa.stft(self.y))
+        s_full, _ = librosa.magphase(librosa.stft(self.time_series))
 
-        idx = slice(*librosa.time_to_frames([30, 35], sr=self.sr))
+        idx = slice(*librosa.time_to_frames([30, 35], sr=self.sampling_rate))
         plt.figure(figsize=(12, 4))
-        disp.specshow(librosa.amplitude_to_db(S_full[:, idx], ref=np.max),
-                    y_axis='log', x_axis='time', sr=self.sr)
+        disp.specshow(librosa.amplitude_to_db(s_full[:, idx], ref=np.max),
+                      y_axis='log', x_axis='time', sr=self.sampling_rate)
         plt.colorbar()
         plt.tight_layout()
 
@@ -101,6 +109,7 @@ class beatSaberSong(object):
 
     def get_beats(self, bpm=120):
         "Identify beat timestamps in the audio."
-        _, beat_frames = librosa.beat.beat_track(self.y, self.sr, bpm=bpm)
-        beat_times = librosa.frames_to_time(beat_frames, sr=self.sr)
+        _, beat_frames = librosa.beat.beat_track(
+            self.time_series, self.sampling_rate, bpm=bpm)
+        beat_times = librosa.frames_to_time(beat_frames, sr=self.sampling_rate)
         return beat_times


### PR DESCRIPTION
Also adds it to run during the build. I intentionally added `|| true` to the script so it doesn't fail the build (it doesn't return success unless the code is absolutely perfect it seems).

Related to #11 and the discussion on there. I also added dev dependencies to enable VS Code to have refactoring enabled etc.

The pylintrc config file is auto generated from pylint. The only change I made was to enable _everything_. We can trim it down as we feel things are overkill. 