### PR TITLE
Add logging module support

### DIFF
--- a/cli/sabergen_cli.py
+++ b/cli/sabergen_cli.py
@@ -5,6 +5,7 @@ sabergen command line tool
 """
 
 import argparse
+import logging
 from sabergen import BeatSaberSong
 
 def main():
@@ -24,16 +25,19 @@ def main():
 
     args = parser.parse_args()
 
-    song = BeatSaberSong(args.debug)
+    log_level = logging.WARNING if not args.debug else logging.INFO
+    logging.basicConfig(level=log_level)
+
+    song = BeatSaberSong()
     song.load(args.input_path)
 
     if args.pyplot:
-        print('Plotting song...')
+        logging.info('Plotting song...')
         song.display_song_as_pyplot()
 
     if args.show_beats:
-        print('Genearting BPM...')
-        print(song.get_beats(args.bpm))
+        logging.info('Genearting BPM...')
+        logging.info(song.get_beats(args.bpm))
 
 if __name__ == '__main__':
     main()

--- a/libsabergen/sabergen.py
+++ b/libsabergen/sabergen.py
@@ -4,6 +4,7 @@
 sabergen library to drive song generation for Beat Saber
 """
 
+import logging
 import numpy as np
 
 import librosa
@@ -22,8 +23,7 @@ class BeatSaberSong:
     audio file into a Beat Saber song.
     """
 
-    def __init__(self, debug=False):
-        self.debug = debug
+    def __init__(self):
         self.time_series = None
         self.sampling_rate = None
         self.audio_path = None
@@ -75,22 +75,19 @@ class BeatSaberSong:
 
             # Command will generate a new file with the same name, except .ogg
             # -c:a codec, -y overwrite if output exists, -q quality specifier
-            subprocess.run("ffmpeg -y -i {} -c:a libvorbis -q:a 8 {}".format(song_path, ogg_path),
-                           shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True)
+            result = subprocess.run(
+                "ffmpeg -y -i {} -c:a libvorbis -q:a 8 {}".format(song_path, ogg_path),
+                shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True)
 
-            if self.debug:
-                # TODO: How best to return stdout/stderr from a library?
-                pass
+            # ffmpeg writes most of its normal output to stderr
+            logging.info(result.stdout)
+            logging.info(result.stderr)
 
             return ogg_path
 
         except subprocess.CalledProcessError as err:
-            # FIXME: Need to find a better way to return a result object to callers
-            # since we likely shouldn't blindly produce stdout/stderr. Perhaps take in a logger?
-            # What logging libraries are popular in Python?
-            print(err.args)
-            print(err.stderr)
-            print(err.stdout)
+            logging.critical(err.stderr)
+            logging.warning(err.stdout)
             raise
 
     def display_song_as_pyplot(self):


### PR DESCRIPTION
Update cli to set appropriate log level based on debug flag

This should close #12. The idea is the application level configures the `logging` module as it desires to for logging (presumably stdout/stderr for cli and files for the webserver) and the library just uses the `logging` module as appropriate.

It may be a bit surprising to have `--debug` mean `INFO` and above but matplotlib and friends have `DEBUG` output which noises things up more than we want (I presume).