### PR TITLE
Add cover art support to ogg conversion and output

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,6 +7,7 @@ name = "pypi"
 librosa = "==0.6.2"
 mutagen = "==1.41.1"
 matplotlib = "==3.0.0"
+pillow = "==5.3.0"
 flask = "==1.0.2"
 libsabergen = {editable = true, path = "./libsabergen"}
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "8f41107f16f175da9d2d6968b23cc4096429749a8ed73f5121662930a396ac2b"
+            "sha256": "28564be38455621ca0078ce2792bb8e76be0e318567feaa6b77bb656bf55c243"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -232,6 +232,42 @@
             ],
             "markers": "python_version >= '2.7' and python_version != '3.0.*' and python_version != '3.1.*' and python_version != '3.2.*' and python_version != '3.3.*'",
             "version": "==1.15.2"
+        },
+        "pillow": {
+            "hashes": [
+                "sha256:00203f406818c3f45d47bb8fe7e67d3feddb8dcbbd45a289a1de7dd789226360",
+                "sha256:0616f800f348664e694dddb0b0c88d26761dd5e9f34e1ed7b7a7d2da14b40cb7",
+                "sha256:1f7908aab90c92ad85af9d2fec5fc79456a89b3adcc26314d2cde0e238bd789e",
+                "sha256:2ea3517cd5779843de8a759c2349a3cd8d3893e03ab47053b66d5ec6f8bc4f93",
+                "sha256:48a9f0538c91fc136b3a576bee0e7cd174773dc9920b310c21dcb5519722e82c",
+                "sha256:5280ebc42641a1283b7b1f2c20e5b936692198b9dd9995527c18b794850be1a8",
+                "sha256:5e34e4b5764af65551647f5cc67cf5198c1d05621781d5173b342e5e55bf023b",
+                "sha256:63b120421ab85cad909792583f83b6ca3584610c2fe70751e23f606a3c2e87f0",
+                "sha256:696b5e0109fe368d0057f484e2e91717b49a03f1e310f857f133a4acec9f91dd",
+                "sha256:870ed021a42b1b02b5fe4a739ea735f671a84128c0a666c705db2cb9abd528eb",
+                "sha256:916da1c19e4012d06a372127d7140dae894806fad67ef44330e5600d77833581",
+                "sha256:9303a289fa0811e1c6abd9ddebfc770556d7c3311cb2b32eff72164ddc49bc64",
+                "sha256:9577888ecc0ad7d06c3746afaba339c94d62b59da16f7a5d1cff9e491f23dace",
+                "sha256:987e1c94a33c93d9b209315bfda9faa54b8edfce6438a1e93ae866ba20de5956",
+                "sha256:99a3bbdbb844f4fb5d6dd59fac836a40749781c1fa63c563bc216c27aef63f60",
+                "sha256:99db8dc3097ceafbcff9cb2bff384b974795edeb11d167d391a02c7bfeeb6e16",
+                "sha256:a5a96cf49eb580756a44ecf12949e52f211e20bffbf5a95760ac14b1e499cd37",
+                "sha256:aa6ca3eb56704cdc0d876fc6047ffd5ee960caad52452fbee0f99908a141a0ae",
+                "sha256:aade5e66795c94e4a2b2624affeea8979648d1b0ae3fcee17e74e2c647fc4a8a",
+                "sha256:b78905860336c1d292409e3df6ad39cc1f1c7f0964e66844bbc2ebfca434d073",
+                "sha256:b92f521cdc4e4a3041cc343625b699f20b0b5f976793fb45681aac1efda565f8",
+                "sha256:bfde84bbd6ae5f782206d454b67b7ee8f7f818c29b99fd02bf022fd33bab14cb",
+                "sha256:c2b62d3df80e694c0e4a0ed47754c9480521e25642251b3ab1dff050a4e60409",
+                "sha256:c5e2be6c263b64f6f7656e23e18a4a9980cffc671442795682e8c4e4f815dd9f",
+                "sha256:c99aa3c63104e0818ec566f8ff3942fb7c7a8f35f9912cb63fd8e12318b214b2",
+                "sha256:dae06620d3978da346375ebf88b9e2dd7d151335ba668c995aea9ed07af7add4",
+                "sha256:db5499d0710823fa4fb88206050d46544e8f0e0136a9a5f5570b026584c8fd74",
+                "sha256:f36baafd82119c4a114b9518202f2a983819101dcc14b26e43fc12cbefdce00e",
+                "sha256:f52b79c8796d81391ab295b04e520bda6feed54d54931708872e8f9ae9db0ea1",
+                "sha256:ff8cff01582fa1a7e533cb97f628531c4014af4b5f38e33cdcfe5eec29b6d888"
+            ],
+            "index": "pypi",
+            "version": "==5.3.0"
         },
         "pyparsing": {
             "hashes": [

--- a/cli/sabergen_cli.py
+++ b/cli/sabergen_cli.py
@@ -40,7 +40,7 @@ def main():
 
     if args.show_beats:
         logging.info('Genearting BPM...')
-        logging.info(song.get_beats(args.bpm))
+        logging.info(song.get_beats())
 
     output.create_song(song)
 

--- a/libsabergen/sabergen/convert.py
+++ b/libsabergen/sabergen/convert.py
@@ -5,8 +5,18 @@ Conversion utilities
 """
 
 import os
+import io
 import subprocess
 import logging
+import base64
+
+from PIL import Image
+
+import mutagen
+from mutagen.oggvorbis import OggVorbis
+from mutagen.flac import Picture
+
+THUMBNAIL_DIMENSION = 512
 
 def is_ogg(song_path):
     "Using the magic number of a file, determine if this is an .ogg file."
@@ -25,6 +35,44 @@ def is_ogg(song_path):
 
     return False
 
+def get_cover_art_from_song(song_path):
+    """
+    Takes in path pointing to an audio file of arbitrary format and finds the cover
+    art, if any, and returns it as a File.
+    """
+    file_type = mutagen.File(song_path)
+
+    pic = None
+
+    # TODO: Look to add support for more tag formats.
+    if isinstance(file_type.tags, mutagen.id3.ID3):
+        apic_frames = [file_type.tags[t] for t in file_type.tags.keys() if t.startswith('APIC')]
+        
+        cover_frame = apic_frames[0]
+        if len(apic_frames) > 1:
+            cover_frame = [f for f in apic_frames if f.type == mutagen.id3.PictureType.COVER_FRONT][0]
+
+        downscaled_data = __downscale_cover_art(cover_frame.data)
+
+        pic = Picture()
+        pic.data = downscaled_data
+        pic.type = cover_frame.type
+        pic.mime = cover_frame.mime
+        pic.width = THUMBNAIL_DIMENSION
+        pic.height = THUMBNAIL_DIMENSION
+        pic.depth = 16 # color depth
+
+    return pic
+
+def __downscale_cover_art(data):
+    "Given data bytes, scale down the image to a reasonable size."
+    img = Image.open(io.BytesIO(data))
+    resized_img = img.resize((THUMBNAIL_DIMENSION, THUMBNAIL_DIMENSION), resample=Image.LANCZOS)
+
+    dest_bytes = io.BytesIO()
+    resized_img.save(dest_bytes, format="jpeg")
+    return dest_bytes.getvalue()
+
 def convert_to_ogg(song_path):
     """
     Converts file at the provided path to ogg.
@@ -40,14 +88,33 @@ def convert_to_ogg(song_path):
         ogg_path = os.path.join(os.path.dirname(song_path), ogg_filename)
 
         # Command will generate a new file with the same name, except .ogg
-        # -c:a codec, -y overwrite if output exists, -q quality specifier
+        # -vn disables video input conversion, -y overwrites if output already exists
+        # -codec:a audio codec, -quality:a audio quality specifier
         result = subprocess.run(
-            "ffmpeg -y -i {} -c:a libvorbis -q:a 8 {}".format(song_path, ogg_path),
+            "ffmpeg -y -i {} -vn -codec:a libvorbis -quality:a 10 {}".format(song_path, ogg_path),
             shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True)
 
         # ffmpeg writes most of its normal output to stderr
         logging.info(result.stdout)
         logging.info(result.stderr)
+
+        # ffmpeg doesn't know how to do covert art in ogg yet
+        # See: https://trac.ffmpeg.org/ticket/4448
+        # Instead, we'll carry over the original covert art ourselves
+        # using Vorbis Comment (https://wiki.xiph.org/VorbisComment)
+        cover_art_picture = get_cover_art_from_song(song_path)
+
+        ogg_file = OggVorbis(ogg_path)
+        cover_art_data = cover_art_picture.write()
+        encoded_data = base64.b64encode(cover_art_data)
+        vcomment_value = encoded_data.decode("utf-8")
+        ogg_file.tags["METADATA_BLOCK_PICTURE"] = [vcomment_value]
+
+        # Delete extraneous cover art keys
+        if "artwork" in ogg_file.tags.keys():
+            del ogg_file.tags["artwork"]
+
+        ogg_file.save(ogg_path)
 
         return ogg_path
 
@@ -55,3 +122,12 @@ def convert_to_ogg(song_path):
         logging.critical(err.stderr)
         logging.warning(err.stdout)
         raise
+
+def get_cover_art(ogg: OggVorbis) -> Image:
+    "Read out cover art as a Pillow Image."
+    ascii_bytes = ogg.tags['METADATA_BLOCK_PICTURE'][0]
+    base64_bytes = ascii_bytes.encode('utf-8')
+    decoded_bytes = base64.b64decode(base64_bytes)
+    pic = Picture(data=decoded_bytes)
+    byte_stream = io.BytesIO(pic.data)
+    return Image.open(byte_stream)

--- a/libsabergen/sabergen/core.py
+++ b/libsabergen/sabergen/core.py
@@ -7,7 +7,7 @@ sabergen library to drive song generation for Beat Saber
 import os
 
 import numpy as np
-import mutagen
+from mutagen.oggvorbis import OggVorbis
 
 import librosa
 import librosa.display as disp
@@ -31,6 +31,8 @@ class BeatSaberSong:
         self.output_path = os.path.abspath(os.path.expanduser(output_path))
         self.audio_path = None
 
+        self.cover_art = None
+
         self.time_series = None
         self.sampling_rate = None
 
@@ -48,11 +50,12 @@ class BeatSaberSong:
 
         self.time_series, self.sampling_rate = librosa.load(self.audio_path)
 
-        metadata = mutagen.File(self.audio_path)
-        self.name = metadata.tags['title'][0]
-        self.album = metadata.tags['album'][0]
-        self.artist = metadata.tags['artist'][0]
-        self.bpm = int(metadata.tags['TBPM'][0])
+        ogg = OggVorbis(self.audio_path)
+        self.name = ogg.tags['title'][0]
+        self.album = ogg.tags['album'][0]
+        self.artist = ogg.tags['artist'][0]
+        self.bpm = int(ogg.tags.get('TBPM', [120])[0])
+        self.cover_art = convert.get_cover_art(ogg)
 
     def display_song_as_pyplot(self):
         "Plots spectrogram magnitude using matplotlib."

--- a/libsabergen/sabergen/output.py
+++ b/libsabergen/sabergen/output.py
@@ -37,8 +37,11 @@ def create_song(song: BeatSaberSong):
     if not os.path.exists(song.output_path):
         os.mkdir(song.output_path)
 
-    audio_destination = os.path.join(song.output_path, 'music.ogg')
-    copyfile(song.audio_path, audio_destination)
+    audio_filename = 'audio.ogg'
+    copyfile(song.audio_path, os.path.join(song.output_path, audio_filename))
+
+    cover_filename = 'cover.jpg'
+    song.cover_art.save(os.path.join(song.output_path, cover_filename))
 
     song_info = {
         'songName': song.name,
@@ -47,8 +50,8 @@ def create_song(song: BeatSaberSong):
         'beatsPerMinute': song.bpm,
         'previewStartTime': 10.0,
         'previewDuration': 20.0,
-        'audioPath': audio_destination,
-        'coverImagePath': '',
+        'audioPath': audio_filename,
+        'coverImagePath': cover_filename,
         'oneSaber': False,
         'noteHitVolume': 1.0,
         'noteMissVolume': 1.0,


### PR DESCRIPTION
This ended up being an interesting journey - [`ffmpeg` has an open bug about how it doesn't support conventional cover art](https://trac.ffmpeg.org/ticket/4448). It instead uses theora to encode the cover as a video stream embedded in the ogg file. This both bloats the ogg file and isn't very useful. I found a [few sources within mutagen's documentation](https://mutagen.readthedocs.io/en/latest/user/vcomment.html) that seemed to paint a hopeful picture of writing it into a conventional location. While this was successful for purposes of pulling the art back out of the ogg for final writing to the destination directory I haven't yet seen the cover art picked up directly from the ogg by applications I've tried. However, that isn't really the objective so it seems fine to leave for now.

This should close #16 