### PR TITLE
Fail build on pylint errors

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,7 +36,7 @@ jobs:
   - script: |
       python_path=`python -m site --user-base`
       pipenv="${python_path}/bin/pipenv"
-      ${pipenv} run pylint --rcfile .pylintrc libsabergen cli webserver || true
+      ${pipenv} run pylint --errors-only --rcfile .pylintrc libsabergen cli webserver
     displayName: 'Run pylint'
 
   - script: |


### PR DESCRIPTION
While working on #17 I noticed that I had accidentally introduced an actual `pylint` error and not noticed - particularly since the build stayed green. This was due to the `|| true` I added to the script as originally it would fail the build if any message was reported (and since everything is enabled that is a lot).

I dug in more and found that we can have it only check for errors on the build which seems better (only fails the build on error) but also less good if we were to actively check the output for things we can do better on (but aren't specifically errors).